### PR TITLE
Fix an issue with globbing for BAT* when it is not present. On Ubuntu 14...

### DIFF
--- a/autoload/promptline/slices/battery.vim
+++ b/autoload/promptline/slices/battery.vim
@@ -33,6 +33,8 @@ fun! promptline#slices#battery#function_body(options)
         \'  fi',
         \'',
         \'  # linux',
+        \'  setopt localoptions',
+        \'  setopt null_glob # ensure globbing BAT* on desktops does not throw an error',
         \'  for possible_battery_dir in /sys/class/power_supply/BAT*; do',
         \'    if [[ -d $possible_battery_dir && -f "$possible_battery_dir/energy_full" && -f "$possible_battery_dir/energy_now" ]]; then',
         \'      current_capacity=$( <"$possible_battery_dir/energy_now" )',


### PR DESCRIPTION
Fix an issue with globbing for BAT\* when it is not present. On Ubuntu 14.04, machines without a battery don't have any BAT\* devices, and zsh throws an error instead of passing an empty glob. http://zshwiki.org/home/options/expn has documentation for the null_glob option.

Prior to this change, machines without a battery print

__promptline_battery:27: no matches found: /sys/class/power_supply/BAT*

before each prompt.
