### PR TITLE
Update git_status.sh, symbol overlaps with numbers

### DIFF
--- a/autoload/promptline/slices/git_status.sh
+++ b/autoload/promptline/slices/git_status.sh
@@ -2,8 +2,8 @@ function __promptline_git_status {
   [[ $(git rev-parse --is-inside-work-tree 2>/dev/null) == true ]] || return 1
 
   local added_symbol="●"
-  local unmerged_symbol="✖"
-  local modified_symbol="✚"
+  local unmerged_symbol="✗"
+  local modified_symbol="+"
   local clean_symbol="✔"
   local has_untracked_files_symbol="…"
 


### PR DESCRIPTION
The original cross and plus symbols have very unusual short width causing the number to overlap which looks very ugly. Changing to version that renders with correct width.
