### PR TITLE
Allow only displaying hostname if connected via SSH

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,1 +1,2 @@
 [Henrique Ferreiro](https://github.com/hferreiro) - fix tilde expansion in bash 4.3
+[Peter Fern](https://github.com/pdf) - Add `only_if_ssh` to host function

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ let g:promptline_preset = {
 " promptline#slices#last_exit_code() - display exit code of last command if not zero
 " promptline#slices#jobs() - display number of shell jobs if more than zero
 " promptline#slices#battery() - display battery percentage (on OSX and linux) only if below 10%. Configure the threshold with promptline#slices#battery({ 'threshold': 25 })
-" promptline#slices#host()
+" promptline#slices#host() - current hostname.  To hide the hostname unless connected via SSH, use promptline#slices#host({ 'only_if_ssh': 1 })
 " promptline#slices#user()
 " promptline#slices#python_virtualenv() - display which virtual env is active (empty is none)
 " promptline#slices#git_status() - count of commits ahead/behind upstream, count of modified/added/unmerged files, symbol for clean branch and symbol for existing untraced files

--- a/autoload/promptline/slices.vim
+++ b/autoload/promptline/slices.vim
@@ -25,8 +25,10 @@ fun! promptline#slices#jobs(...)
 endfun
 
 fun! promptline#slices#host(...)
-  " host is \h in bash, %m in zsh
-  return '$(if [[ -n ${ZSH_VERSION-} ]]; then print %m; elif [[ -n ${FISH_VERSION-} ]]; then hostname -s; else printf "%s" \\h; fi )'
+  let options = get(a:, 1, {})
+  return {
+        \'function_name': '__promptline_host',
+        \'function_body': promptline#slices#host#function_body(options)}
 endfun
 
 fun! promptline#slices#user(...)

--- a/autoload/promptline/slices/host.vim
+++ b/autoload/promptline/slices/host.vim
@@ -1,0 +1,12 @@
+fun! promptline#slices#host#function_body( options )
+  let only_if_ssh = get(a:options, 'only_if_ssh', 0)
+  let lines = [
+        \'function __promptline_host {',
+        \'  local only_if_ssh="' . only_if_ssh . '"',
+        \'',
+        \'  if [ ! $only_if_ssh -o -n "${SSH_CLIENT}" ]; then',
+        \'    if [[ -n ${ZSH_VERSION-} ]]; then print %m; elif [[ -n ${FISH_VERSION-} ]]; then hostname -s; else printf "%s" \\h; fi',
+        \'  fi',
+        \'}']
+	return lines
+endfun


### PR DESCRIPTION
Adds an option `only_if_ssh` to the host function to allow hiding hostname on
the local host