### PR TITLE
Add indicator for stash and WIP to git status bar

### DIFF
--- a/autoload/promptline/slices/git_status.sh
+++ b/autoload/promptline/slices/git_status.sh
@@ -6,6 +6,7 @@ function __promptline_git_status {
   local modified_symbol="+"
   local clean_symbol="✔"
   local has_untracked_files_symbol="…"
+  local stash_symbol="↥"
 
   local ahead_symbol="↑"
   local behind_symbol="↓"
@@ -15,6 +16,9 @@ function __promptline_git_status {
   set -- $(git rev-list --left-right --count @{upstream}...HEAD 2>/dev/null)
   local behind_count=$1
   local ahead_count=$2
+
+  set -- $(git stash list | wc -l)
+  local stash_count=$1;
 
   # Added (A), Copied (C), Deleted (D), Modified (M), Renamed (R), changed (T), Unmerged (U), Unknown (X), Broken (B)
   while read line; do
@@ -46,4 +50,5 @@ function __promptline_git_status {
   [[ $added_count -gt 0 ]]         && { printf "%s" "$leading_whitespace$added_symbol$added_count"; leading_whitespace=" "; }
   [[ $has_untracked_files -gt 0 ]] && { printf "%s" "$leading_whitespace$has_untracked_files_symbol"; leading_whitespace=" "; }
   [[ $is_clean -gt 0 ]]            && { printf "%s" "$leading_whitespace$clean_symbol"; leading_whitespace=" "; }
+  [[ $stash_count -gt 0 ]]         && { printf "%s" "$leading_whitespace$stash_symbol$stash_count"; leading_whitespace=" "; }
 }

--- a/autoload/promptline/slices/git_status.sh
+++ b/autoload/promptline/slices/git_status.sh
@@ -7,6 +7,7 @@ function __promptline_git_status {
   local clean_symbol="✔"
   local has_untracked_files_symbol="…"
   local stash_symbol="↥"
+  local wip_symbol="[WIP]"
 
   local ahead_symbol="↑"
   local behind_symbol="↓"
@@ -20,6 +21,8 @@ function __promptline_git_status {
   set -- $(git stash list | wc -l)
   local stash_count=$1;
 
+  set -- $(git log -n 1 | grep -c "\-\-wip\-\-")
+  local wip_count=$1;
   # Added (A), Copied (C), Deleted (D), Modified (M), Renamed (R), changed (T), Unmerged (U), Unknown (X), Broken (B)
   while read line; do
     case "$line" in
@@ -51,4 +54,5 @@ function __promptline_git_status {
   [[ $has_untracked_files -gt 0 ]] && { printf "%s" "$leading_whitespace$has_untracked_files_symbol"; leading_whitespace=" "; }
   [[ $is_clean -gt 0 ]]            && { printf "%s" "$leading_whitespace$clean_symbol"; leading_whitespace=" "; }
   [[ $stash_count -gt 0 ]]         && { printf "%s" "$leading_whitespace$stash_symbol$stash_count"; leading_whitespace=" "; }
+  [[ $wip_count -gt 0 ]]           && { printf "%s" "$leading_whitespace$wip_symbol"; leading_whitespace=" "; }
 }


### PR DESCRIPTION
For stash it displays the number of stashed changes, if any.

For WIP it displays a `[WIP]` indicator if the current git branch is [`gwip`'ed](https://github.com/robbyrussell/oh-my-zsh/blob/master/plugins/git/git.plugin.zsh#L240)
