### PR TITLE
fix git_status ahead/behind counts

### DIFF
--- a/autoload/promptline/slices/git_status.sh
+++ b/autoload/promptline/slices/git_status.sh
@@ -12,7 +12,7 @@ function __promptline_git_status {
 
   local unmerged_count=0 modified_count=0 has_untracked_files=0 added_count=0 is_clean=""
 
-  set -- $(git rev-list --left-right --count @{upstream}...HEAD 2>/dev/null)
+  set -- $(git rev-list --left-right --count "@{upstream}...HEAD" 2>/dev/null)
   local behind_count=$1
   local ahead_count=$2
 


### PR DESCRIPTION
This fixes the call to git to retrieve `behind_count`/`ahead_count`.

Using the following versions:

git version 2.15.0
zsh 5.4.2 (x86_64-apple-darwin15.6.0)

The current implementation throws an error, but quoting the arguments fixes it:

```
$ git rev-list --left-right --count @{upstream}...HEAD
fatal: ambiguous argument '@a...HEAD': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'

$ git rev-list --left-right --count "@{upstream}...HEAD"
0	1
```