### PR TITLE
Fix installation instructions to use promptline.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,18 +30,18 @@ More screenshots can be found in the [wiki](https://github.com/edkolev/promptlin
 
 #### Quick Start with airline installed
 
-1. In vim `:PromptlineSnapshot ~/.shell_prompt.sh airline`
-2. In bash/zsh `source ~/.shell_prompt.sh`
+1. In vim `:PromptlineSnapshot ~/.promptline.sh airline`
+2. In bash/zsh `source ~/.promptline.sh`
 
 #### Quick Start with lightline installed
 
-1. In vim `:PromptlineSnapshot ~/.shell_prompt.sh lightline`
-2. In bash/zsh `source ~/.shell_prompt.sh`
+1. In vim `:PromptlineSnapshot ~/.promptline.sh lightline`
+2. In bash/zsh `source ~/.promptline.sh`
 
 #### Quick Start
 
-1. In vim `:PromptlineSnapshot ~/.shell_prompt.sh`
-2. In bash/zsh `source ~/.shell_prompt.sh`
+1. In vim `:PromptlineSnapshot ~/.promptline.sh`
+2. In bash/zsh `source ~/.promptline.sh`
 
 ## Usage
 


### PR DESCRIPTION
Quick start instructions create the file `.shell_prompt.sh`, but the fish instructions use `.promptline.sh`. Seeing as the project is called "promptline", I think that the file should always be called `promptline.sh`.
Otherwise, if you think the file should be called `.shell_prompt.sh`, change the `config.fish` instructions to use it rather than `.promptline.sh`.