### PR TITLE
cwd slice: enable customization of tilde symbol

### DIFF
--- a/autoload/promptline.vim
+++ b/autoload/promptline.vim
@@ -93,7 +93,7 @@ fun! s:get_shell_escape_codes()
         \'  elif [[ -n ${FISH_VERSION-} ]]; then',
         \"    local noprint='' end_noprint=''",
         \'  else',
-        \"    local noprint='\\[' end_noprint='\\]'",
+        \"    local noprint='' end_noprint=''",
         \'  fi',
         \'  local wrap="$noprint$esc" end_wrap="$end_esc$end_noprint"']
 endfun
@@ -110,7 +110,7 @@ fun! s:get_prompt_variables_installation(prompt)
         \'      __promptline_ps1',
         \'    fi',
         \'  else',
-        \'    PS1="' . join(a:prompt.sections, '') . '"',
+        \'    printf %s "' . join(a:prompt.sections, '') . '"',
         \'  fi']
 endfun
 
@@ -185,9 +185,7 @@ fun! s:get_prompt_installation()
       \'elif [[ -n ${FISH_VERSION-} ]]; then',
       \'  __promptline "$1"',
       \'else',
-      \'  if [[ ! "$PROMPT_COMMAND" == *__promptline* ]]; then',
-      \"    PROMPT_COMMAND='__promptline;'$'\\n'\"$PROMPT_COMMAND\"",
-      \'  fi',
+      \"  PS1='$(__promptline)'",
       \'fi']
 endfun
 

--- a/autoload/promptline/slices.vim
+++ b/autoload/promptline/slices.vim
@@ -52,8 +52,13 @@ fun! promptline#slices#conda_env(...)
 endfun
 
 fun! promptline#slices#git_status(...)
+  if exists('*nvim_get_runtime_file')
+    let file_name = nvim_get_runtime_file("autoload/promptline/slices/git_status.sh", v:false)[0]
+  else
+    let file_name = globpath(&rtp, "autoload/promptline/slices/git_status.sh")
+  endif
   return { 'function_name': '__promptline_git_status',
-          \'function_body': readfile(globpath(&rtp, "autoload/promptline/slices/git_status.sh"))}
+          \'function_body': readfile(file_name)}
 endfun
 
 " internally used to wrap any string, like \w, \h, $(command) with the given colors / separators

--- a/autoload/promptline/slices/cwd.vim
+++ b/autoload/promptline/slices/cwd.vim
@@ -1,6 +1,7 @@
 fun! promptline#slices#cwd#function_body( options )
   let dir_limit = get(a:options, 'dir_limit', 3)
   let dir_sep = promptline#symbols#get().dir_sep
+  let tilde = promptline#symbols#get().cwd_home
   let truncation = promptline#symbols#get().truncation
   let lines = [
         \'function __promptline_cwd {',
@@ -10,7 +11,7 @@ fun! promptline#slices#cwd#function_body( options )
         \'  local part_count=0',
         \'  local formatted_cwd=""',
         \'  local dir_sep="' . dir_sep . '"',
-        \'  local tilde="~"',
+        \'  local tilde="' . tilde . '"',
         \'',
         \'  local cwd="${PWD/#$HOME/$tilde}"',
         \'',

--- a/autoload/promptline/symbols.vim
+++ b/autoload/promptline/symbols.vim
@@ -8,6 +8,7 @@ let s:simple_symbols = {
     \ 'left_alt'       : '|',
     \ 'right_alt'      : '|',
     \ 'dir_sep'        : ' / ',
+    \ 'cwd_home'       : '~',
     \ 'truncation'     : '...',
     \ 'vcs_branch'     : '',
     \ 'battery'        : '',


### PR DESCRIPTION
Because I always edit the result of `PromptlineSnapshot` to use `🏠` (U+1F3E0 HOUSE BUILDING) for `$HOME`. ☺