### PR TITLE
Add Kubernetes section

### DIFF
--- a/autoload/promptline/slices.vim
+++ b/autoload/promptline/slices.vim
@@ -56,6 +56,12 @@ fun! promptline#slices#git_status(...)
           \'function_body': readfile(globpath(&rtp, "autoload/promptline/slices/git_status.sh"))}
 endfun
 
+fun! promptline#slices#kubernetes(...)
+  return {
+        \'function_name': '__promptline_kubernetes',
+        \'function_body': readfile(globpath(&rtp, "autoload/promptline/slices/kubernetes.sh"))}
+endfun
+
 " internally used to wrap any string, like \w, \h, $(command) with the given colors / separators
 fun! promptline#slices#wrapper(...)
   return {
@@ -69,3 +75,4 @@ fun! promptline#slices#wrapper(...)
           \'  printf "%s" "${2}${1}${3}"',
           \'}']}
 endfun
+

--- a/autoload/promptline/slices/kubernetes.sh
+++ b/autoload/promptline/slices/kubernetes.sh
@@ -1,0 +1,5 @@
+function __promptline_kubernetes {
+  if [ -x "$(command -v kubectl)" ]; then
+    printf "\u2388 %s" "$(kubectl config current-context)"
+  fi
+}

--- a/autoload/promptline/slices/kubernetes.sh
+++ b/autoload/promptline/slices/kubernetes.sh
@@ -1,5 +1,5 @@
 function __promptline_kubernetes {
   if [ -x "$(command -v kubectl)" ]; then
-    printf "\u2388 %s" "$(kubectl config current-context)"
+    printf "⎈ %s" "$(kubectl config current-context)"
   fi
 }


### PR DESCRIPTION
Fixes #78 .

## Changelog

- Add a new script which prints the current Kubernetes cluster prefixed with the Kubernetes icon.
-  Add a new section/slice `promptline#slices#kubernetes()`