### PR TITLE
Add an option to start typing on a new line

### DIFF
--- a/autoload/promptline/presets.vim
+++ b/autoload/promptline/presets.vim
@@ -2,6 +2,7 @@
 "
 " Copyright (c) 2013-2019 Evgeni Kolev
 
+let s:DEFAULT_NEWLINE = 0
 let s:DEFAULT_LEFT_ONLY_SECTIONS = [ 'a', 'b', 'c', 'x', 'y', 'z', 'warn' ]
 let s:DEFAULT_LEFT_SECTIONS      = [ 'a', 'b', 'c' ]
 let s:DEFAULT_RIGHT_SECTIONS     = [ 'warn', 'x', 'y', 'z' ]
@@ -16,6 +17,7 @@ fun! promptline#presets#load_preset(preset) abort
   endif
 
   let preset.options = extend(get(preset, 'options', {}), {
+        \'newline': s:DEFAULT_NEWLINE,
         \'left_sections': filter(copy(s:DEFAULT_LEFT_SECTIONS), 'has_key(preset, v:val)'),
         \'right_sections': filter(copy(s:DEFAULT_RIGHT_SECTIONS), 'has_key(preset, v:val)'),
         \'left_only_sections': filter(copy(s:DEFAULT_LEFT_ONLY_SECTIONS), 'has_key(preset, v:val)')}, 'keep')

--- a/autoload/promptline/sections.vim
+++ b/autoload/promptline/sections.vim
@@ -91,7 +91,8 @@ fun! s:make_function( function_name, preset, section_names, is_left )
     endfor
   endfor
 
-  let section_closing = a:is_left ? '"${reset_bg}${sep}$reset$space"' : '"$reset"'
+  let left_section_closing = a:preset.options.newline ? '"${reset_bg}${sep}$reset\n"' : '"${reset_bg}${sep}$reset$space"' 
+  let section_closing = a:is_left ? left_section_closing : '"$reset"'
   let func_body += [
         \'',
         \'  # close sections',


### PR DESCRIPTION
This is added as an option to the preset. This allows users to populate
their promptline with slices while resting assured that they still have
a full new line in which they can enter their commands.

Refs#35
Refs#48