### PR TITLE
Fix rtp not including packages in neovim

### DIFF
--- a/autoload/promptline/slices.vim
+++ b/autoload/promptline/slices.vim
@@ -52,8 +52,14 @@ fun! promptline#slices#conda_env(...)
 endfun
 
 fun! promptline#slices#git_status(...)
+  let script = "autoload/promptline/slices/git_status.sh"
+  if exists('*nvim_get_runtime_file')
+    let script = nvim_get_runtime_file(script, v:false)[0]
+  else
+    let script = globpath(&rtp, script)
+  endif
   return { 'function_name': '__promptline_git_status',
-          \'function_body': readfile(globpath(&rtp, "autoload/promptline/slices/git_status.sh"))}
+          \'function_body': readfile(script)}
 endfun
 
 " internally used to wrap any string, like \w, \h, $(command) with the given colors / separators


### PR DESCRIPTION
Based on [nvim docs](https://neovim.io/doc/user/repeat.html#runtime-search-path):
> Package entries are not visible in `:set rtp` or `echo &rtp`, as the final concatenated path would be too long and get truncated.

Thus we will have to use `nvim_get_runtime_file` to support installing this as a package in nvim.

I am not familiar with vim script, so please help comment if my code is not idiomatic. Thanks!